### PR TITLE
Add a loader for the non-classed items

### DIFF
--- a/lib/Horde/Nls/Loader.php
+++ b/lib/Horde/Nls/Loader.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * OOP-style loader for various NLS data
+ * 
+ * As of H5, at least turba and Forms make assumptions about the filesystem
+ * location of the data files and make an unconditional cross-library include.
+ * 
+ * This breaks for composer or other layouts. Use this wrapper but leave the original
+ * files unchanged for backward compat
+ * 
+ * @TODO H6: Namespaced version of Horde_Nls should wrap these data into proper classes
+ * @TODO H7: Remove backward compat
+ */
+class Horde_Nls_Loader
+{
+    public static function loadCarsigns(): array
+    {
+        include 'Carsigns.php';
+        return $carsigns;
+    }
+    public static function loadCountries(): array
+    {
+        include 'Countries.php';
+        return $countries;
+    }
+    public static function loadCoordinates(): array
+    {
+        include 'Coordinates.php';
+        return $coordinates;
+    }
+    public function loadAlpha3(): array
+    {
+        include 'Alpha3.php';
+        return $alpha3;
+    }
+    public function loadLanguages(): array
+    {
+        include 'Languages.php';
+        return $languages;
+    }
+    public function loadTld(): array
+    {
+        include 'Tld.php';
+        return $tld;
+    }
+}


### PR DESCRIPTION
Some parts in turba, forms and most likely some other apps try to load nls data arrays through relative autoload paths. this works in PEAR but not in composer or other autoload scenarios. The loader is an autoloadable item which, in turn, has a stable relative path to the data files.

This change is backward compatible, untouched code will not break (if it worked before).

The suggested idiom to use the loader is:

        /* Countries */
        if (class_exists(\Horde_Nls_Loader::class)) {
            $countries = \Horde_Nls_Loader::loadCountries();
        } else {
            include 'Horde/Nls/Countries.php';
        }

This will work both with older NLS libraries or with scenarios where the class cannot be autoloaded, provided that the include path works (backward compat).